### PR TITLE
Add null-safety checks to log parsing

### DIFF
--- a/ApsLog.py
+++ b/ApsLog.py
@@ -34,10 +34,14 @@ class ApsLog:
                 # Detect the encoding
                 with open(self.file_path, 'rb') as file:
                     raw_data = file.read()
-                    detected_encoding = chardet.detect(raw_data)['encoding']
-                
+                    detected = chardet.detect(raw_data)
+                    detected_encoding = detected.get('encoding') if isinstance(detected, dict) else None
+
+                if not detected_encoding:
+                    detected_encoding = 'utf-8'
+
                 logger.info(f"Detected encoding for {self.file_path }: {detected_encoding}")  # Debug statement
-                
+
                 # Try opening the file with the detected encoding
                 log_entries = []
                 try:
@@ -141,10 +145,14 @@ class ApsLog:
                         # Detect the encoding
                         with open(self.file_path, 'rb') as file:
                             raw_data = file.read()
-                            detected_encoding = chardet.detect(raw_data)['encoding']
-                        
+                            detected = chardet.detect(raw_data)
+                            detected_encoding = detected.get('encoding') if isinstance(detected, dict) else None
+
+                        if not detected_encoding:
+                            detected_encoding = 'utf-8'
+
                         logger.info(f"Detected encoding for {self.file_path}: {detected_encoding}")  # Debug statement
-                        
+
                         # Try opening the file with the detected encoding
                         try:
                             with open(self.file_path, 'r', encoding=detected_encoding ) as file:
@@ -166,17 +174,20 @@ class ApsLog:
 
     def extract_log_entries(self, soup):
         log_entries = []
-        
+
+        if not soup:
+            return log_entries
+
         log_section = soup.find('a', {'name': 'LogEntries'})
         if log_section:
             log_table = log_section.find_next('table')
-            
+
             if log_table:
                 rows = log_table.find_all('tr')[1:]
-        
+
                 for row in rows:
                     cells = row.find_all('td')
-                    if len(cells) != 0:
+                    if len(cells) > 3:
                         description = cells[3].text.strip()
                         user = server = process = pid = session = ''
                         

--- a/BasicInfo.py
+++ b/BasicInfo.py
@@ -3,41 +3,56 @@ import os
 from ApsLogs import load_log_file
 
 def get_basic_info(path: str):
+    if not path:
+        raise ValueError("Path cannot be None")
+
     info = {
         'hostOS': None,
         'hostVersion': None,
         'clientVersions': []
     }
-    
+
     if os.path.exists(path) and os.path.isdir(path):
         for file in os.listdir(path):
             if file.endswith(".html"):
                 soup = load_log_file(os.path.join(path, file))
-                info['hostOS'] = get_host_version(soup)
-                info['hostVersion'] = get_platform_version(soup)
-                info['clientVersions'] = get_client_versions(soup)
+                if soup:
+                    info['hostOS'] = get_host_version(soup)
+                    info['hostVersion'] = get_platform_version(soup)
+                    info['clientVersions'] = get_client_versions(soup)
     else:
-        raise Exception(ValueError)
+        raise ValueError("Invalid path: {path}")
 
     return info
 
 def get_host_version(soup):
-    # Extract Product Version
-    product_info_table = soup.find_all('table')[1]
+    if not soup:
+        return ''
+
+    tables = soup.find_all('table')
+    if len(tables) < 2:
+        return ''
+
+    product_info_table = tables[1]
     rows = product_info_table.find_all('tr')
-    
+
     for row in rows:
         cells = row.find_all('td')
-        if 'Product Version' in cells[0].text:
+        if cells and 'Product Version' in cells[0].text:
             return cells[1].text.strip()
-    
+
     return ''
 
 def get_client_versions(log_entries):
     client_versions = []
 
+    if not log_entries:
+        return client_versions
+
     for entry in log_entries:
-        descr = entry['description']
+        descr = entry.get('description') if isinstance(entry, dict) else None
+        if not descr:
+            continue
         if "The version of the" in descr:
             parts = descr.split('The version of the ')
             for part in parts[1:]:
@@ -50,13 +65,22 @@ def get_client_versions(log_entries):
 def get_client_versions(soup):
     client_versions = []
 
+    if not soup:
+        return client_versions
+
     log_section = soup.find('a', {'name': 'LogEntries'})
+    if not log_section:
+        return client_versions
+
     log_table = log_section.find_next('table')
+    if not log_table:
+        return client_versions
+
     rows = log_table.find_all('tr')[1:]
-    
+
     for row in rows:
         cells = row.find_all('td')
-        if len(cells) != 0:
+        if len(cells) > 3:
             descr = cells[3].text.strip()
             if "The version of the" in descr:
                 parts = descr.split('The version of the ')
@@ -70,22 +94,37 @@ def get_client_versions(soup):
 def get_platform_version(log_entries):
     platform_version = None
     platform_build_number = None
-    
+
+    if not log_entries:
+        return "Not found"
+
     for entry in log_entries:
-        if "The current operating system is" in entry['Description']:
-            return entry['Description'].split("is")[1].strip()
-    
+        description = entry.get('Description') if isinstance(entry, dict) else None
+        if description and "The current operating system is" in description:
+            return description.split("is")[1].strip()
+
     return "Not found"
 
 def get_platform_version(soup):
+    if not soup:
+        return "Unknown"
+
     operating_env_section = soup.find('a', {'name': 'EnvOp'})
-    if operating_env_section:
-        env_table = operating_env_section.find_next('table')
-        env_rows = env_table.find_all('tr')
-        
-        for row in env_rows:
-            cells = row.find_all('td')
-            if len(cells) > 0 and 'Platform Build Number' in cells[0].text:
-                build_num = cells[1].text.split('.')[0]
-                return GOGlobal.supported_platforms[build_num] if GOGlobal.supported_platforms[build_num] else build_num
-    
+    if not operating_env_section:
+        return "Unknown"
+
+    env_table = operating_env_section.find_next('table')
+    if not env_table:
+        return "Unknown"
+
+    env_rows = env_table.find_all('tr')
+
+    for row in env_rows:
+        cells = row.find_all('td')
+        if len(cells) > 1 and 'Platform Build Number' in cells[0].text:
+            build_num = cells[1].text.split('.')[0]
+            platform = GOGlobal.supported_platforms.get(build_num)
+            return platform if platform else build_num
+
+    return "Unknown"
+


### PR DESCRIPTION
## Summary
- guard against null or invalid paths when collecting basic info
- check soup and table structure before parsing host and client details
- default to UTF-8 when encoding detection fails and validate HTML before parsing log entries

## Testing
- `python -m py_compile ApsLog.py BasicInfo.py`


------
https://chatgpt.com/codex/tasks/task_b_68b9b30ef9bc832c84d802e3243ff6dd